### PR TITLE
Add JWT package and authentication logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ docker-compose up
 
 ```bash
 ./d.sh php
+cp .env.example .env
 php artisan key:generate
 ```
 

--- a/app/Data/Models/User.php
+++ b/app/Data/Models/User.php
@@ -3,12 +3,13 @@
 namespace App\Data\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
-class User extends Authenticatable
+class User extends Authenticatable implements JWTSubject
 {
     use HasApiTokens, HasFactory, Notifiable;
 
@@ -41,4 +42,24 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    /**
+     * Get the identifier that will be stored in the subject claim of the JWT.
+     *
+     * @return mixed
+     */
+    public function getJWTIdentifier()
+    {
+        return $this->getKey();
+    }
+
+    /**
+     * Return a key value array, containing any custom claims to be added to the JWT.
+     *
+     * @return array
+     */
+    public function getJWTCustomClaims()
+    {
+        return [];
+    }
 }

--- a/app/EntryPoints/Http/Auth/ActionsRequests/AuthLoginRequest.php
+++ b/app/EntryPoints/Http/Auth/ActionsRequests/AuthLoginRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\EntryPoints\Http\Auth\ActionsRequests;
+
+use App\Foundation\Abstracts\Request;
+use App\Foundation\Interfaces\RequestInterface;
+
+class AuthLoginRequest extends Request implements RequestInterface
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|string|email',
+            'password' => 'required|string'
+        ];
+    }
+}

--- a/app/EntryPoints/Http/Auth/AuthController.php
+++ b/app/EntryPoints/Http/Auth/AuthController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\EntryPoints\Http\Auth;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redis;
+use App\Foundation\Laravel\AppController;
+use App\EntryPoints\Http\Auth\ActionsRequests\{
+    AuthLoginRequest,
+};
+use App\Foundation\Laravel\Responses\{
+    SuccessResponse,
+    ErrorResponse
+};
+use Throwable;
+
+class AuthController extends AppController {
+    const SECONDS_IN_MINUTE = 60;
+
+    public function login(
+        AuthLoginRequest $request): ErrorResponse|SuccessResponse
+    {
+        try {
+            $credentials = $request->only('email', 'password');
+            if (!$token = auth()->attempt($credentials)) {
+                return new ErrorResponse('Unauthorized', null, 401);
+            }
+
+            $this->setToken(
+                auth()->user()->id,
+                $token
+            );
+
+            return new SuccessResponse([
+                'token' => $token,
+                'type' => 'bearer'
+            ]);
+        } catch (Throwable $exception) {
+            return new ErrorResponse(
+                'An error occurred while login attempt',
+                $exception
+            );
+        }
+    }
+
+    public function logout(): ErrorResponse|SuccessResponse
+    {
+        try {
+            $userId = auth()->user()->id;
+            auth()->logout();
+            Redis::del("user:{$userId}:jwt_token");
+
+            return new SuccessResponse([
+                'message' => 'Successfully logged out',
+            ]);
+        } catch (Throwable $exception) {
+            return new ErrorResponse(
+                'An error occurred while logout process',
+                $exception
+            );
+        }
+    }
+
+    public function refresh(): ErrorResponse|SuccessResponse
+    {
+        try {
+            $newToken = auth()->refresh();
+            $this->setToken(
+                auth()->user()->id,
+                $newToken
+            );
+
+            return new SuccessResponse([
+                'token' => $newToken,
+                'type' => 'bearer'
+            ]);
+        } catch (Throwable $exception) {
+            return new ErrorResponse(
+                'An error occurred while token refresh',
+                $exception
+            );
+        }
+    }
+
+    private function setToken(int $id, string $token): void
+    {
+        Redis::setex(
+            "user:{$id}:jwt_token",
+            env('JWT_TTL') * self::SECONDS_IN_MINUTE,
+            $token
+        );
+    }
+}

--- a/app/EntryPoints/Routes/app/auth.php
+++ b/app/EntryPoints/Routes/app/auth.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::namespace('Auth')->prefix('auth')->group(static function () {
+    // Put the routes here
+    Route::post('/refresh-token', 'AuthController@refresh')->name('jwt.auth.refresh.token');
+    Route::post('/logout', 'AuthController@logout')->name('jwt.auth.logout');
+});

--- a/app/Foundation/Laravel/Providers/RouteServiceProvider.php
+++ b/app/Foundation/Laravel/Providers/RouteServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Foundation\Laravel\Providers;
 
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use App\EntryPoints\Http\Auth\AuthController;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
@@ -29,6 +30,9 @@ class RouteServiceProvider extends ServiceProvider
             Route::get('login', function () {
                 return redirect('/');
             })->name('login');
+
+            Route::prefix('api/app/auth')
+                ->post('/login', [AuthController::class, 'login'])->name('jwt.auth.login');
 
             Route::middleware(['AppAPI', 'auth:api'])
                 ->group(static function () {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.19",
         "laravel/sanctum": "^3.0",
-        "laravel/tinker": "^2.7"
+        "laravel/tinker": "^2.7",
+        "php-open-source-saver/jwt-auth": "*"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/config/jwt.php
+++ b/config/jwt.php
@@ -1,0 +1,300 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | JWT Authentication Secret
+    |--------------------------------------------------------------------------
+    |
+    | Don't forget to set this in your .env file, as it will be used to sign
+    | your tokens. A helper command is provided for this:
+    | `php artisan jwt:secret`
+    |
+    | Note: This will be used for Symmetric algorithms only (HMAC),
+    | since RSA and ECDSA use a private/public key combo (See below).
+    |
+    */
+
+    'secret' => env('JWT_SECRET'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | JWT Authentication Keys
+    |--------------------------------------------------------------------------
+    |
+    | The algorithm you are using, will determine whether your tokens are
+    | signed with a random string (defined in `JWT_SECRET`) or using the
+    | following public & private keys.
+    |
+    | Symmetric Algorithms:
+    | HS256, HS384 & HS512 will use `JWT_SECRET`.
+    |
+    | Asymmetric Algorithms:
+    | RS256, RS384 & RS512 / ES256, ES384 & ES512 will use the keys below.
+    |
+    */
+
+    'keys' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Public Key
+        |--------------------------------------------------------------------------
+        |
+        | A path or resource to your public key.
+        |
+        | E.g. 'file://path/to/public/key'
+        |
+        */
+
+        'public' => env('JWT_PUBLIC_KEY'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Private Key
+        |--------------------------------------------------------------------------
+        |
+        | A path or resource to your private key.
+        |
+        | E.g. 'file://path/to/private/key'
+        |
+        */
+
+        'private' => env('JWT_PRIVATE_KEY'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Passphrase
+        |--------------------------------------------------------------------------
+        |
+        | The passphrase for your private key. Can be null if none set.
+        |
+        */
+
+        'passphrase' => env('JWT_PASSPHRASE'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | JWT time to live
+    |--------------------------------------------------------------------------
+    |
+    | Specify the length of time (in minutes) that the token will be valid for.
+    | Defaults to 1 hour.
+    |
+    | You can also set this to null, to yield a never expiring token.
+    | Some people may want this behaviour for e.g. a mobile app.
+    | This is not particularly recommended, so make sure you have appropriate
+    | systems in place to revoke the token if necessary.
+    | Notice: If you set this to null you should remove 'exp' element from 'required_claims' list.
+    |
+    */
+
+    'ttl' => env('JWT_TTL', 60),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Refresh time to live
+    |--------------------------------------------------------------------------
+    |
+    | Specify the length of time (in minutes) that the token can be refreshed
+    | within. I.E. The user can refresh their token within a 2 week window of
+    | the original token being created until they must re-authenticate.
+    | Defaults to 2 weeks.
+    |
+    | You can also set this to null, to yield an infinite refresh time.
+    | Some may want this instead of never expiring tokens for e.g. a mobile app.
+    | This is not particularly recommended, so make sure you have appropriate
+    | systems in place to revoke the token if necessary.
+    |
+    */
+
+    'refresh_ttl' => env('JWT_REFRESH_TTL', 20160),
+
+    /*
+    |--------------------------------------------------------------------------
+    | JWT hashing algorithm
+    |--------------------------------------------------------------------------
+    |
+    | Specify the hashing algorithm that will be used to sign the token.
+    |
+    | See here: https://github.com/namshi/jose/tree/master/src/Namshi/JOSE/Signer/OpenSSL
+    | for possible values.
+    |
+    */
+
+    'algo' => env('JWT_ALGO', 'HS256'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Required Claims
+    |--------------------------------------------------------------------------
+    |
+    | Specify the required claims that must exist in any token.
+    | A TokenInvalidException will be thrown if any of these claims are not
+    | present in the payload.
+    |
+    */
+
+    'required_claims' => [
+        'iss',
+        'iat',
+        'exp',
+        'nbf',
+        'sub',
+        'jti',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Persistent Claims
+    |--------------------------------------------------------------------------
+    |
+    | Specify the claim keys to be persisted when refreshing a token.
+    | `sub` and `iat` will automatically be persisted, in
+    | addition to the these claims.
+    |
+    | Note: If a claim does not exist then it will be ignored.
+    |
+    */
+
+    'persistent_claims' => [
+        // 'foo',
+        // 'bar',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Lock Subject
+    |--------------------------------------------------------------------------
+    |
+    | This will determine whether a `prv` claim is automatically added to
+    | the token. The purpose of this is to ensure that if you have multiple
+    | authentication models e.g. `App\User` & `App\OtherPerson`, then we
+    | should prevent one authentication request from impersonating another,
+    | if 2 tokens happen to have the same id across the 2 different models.
+    |
+    | Under specific circumstances, you may want to disable this behaviour
+    | e.g. if you only have one authentication model, then you would save
+    | a little on token size.
+    |
+    */
+
+    'lock_subject' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Leeway
+    |--------------------------------------------------------------------------
+    |
+    | This property gives the jwt timestamp claims some "leeway".
+    | Meaning that if you have any unavoidable slight clock skew on
+    | any of your servers then this will afford you some level of cushioning.
+    |
+    | This applies to the claims `iat`, `nbf` and `exp`.
+    |
+    | Specify in seconds - only if you know you need it.
+    |
+    */
+
+    'leeway' => env('JWT_LEEWAY', 0),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Blacklist Enabled
+    |--------------------------------------------------------------------------
+    |
+    | In order to invalidate tokens, you must have the blacklist enabled.
+    | If you do not want or need this functionality, then set this to false.
+    |
+    */
+
+    'blacklist_enabled' => env('JWT_BLACKLIST_ENABLED', true),
+
+    /*
+    | -------------------------------------------------------------------------
+    | Blacklist Grace Period
+    | -------------------------------------------------------------------------
+    |
+    | When multiple concurrent requests are made with the same JWT,
+    | it is possible that some of them fail, due to token regeneration
+    | on every request.
+    |
+    | Set grace period in seconds to prevent parallel request failure.
+    |
+    */
+
+    'blacklist_grace_period' => env('JWT_BLACKLIST_GRACE_PERIOD', 0),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Show blacklisted token option
+    |--------------------------------------------------------------------------
+    |
+    | Specify if you want to show black listed token exception on the laravel logs.
+    |
+    */
+
+    'show_black_list_exception' => env('JWT_SHOW_BLACKLIST_EXCEPTION', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cookies encryption
+    |--------------------------------------------------------------------------
+    |
+    | By default Laravel encrypt cookies for security reason.
+    | If you decide to not decrypt cookies, you will have to configure Laravel
+    | to not encrypt your cookie token by adding its name into the $except
+    | array available in the middleware "EncryptCookies" provided by Laravel.
+    | see https://laravel.com/docs/master/responses#cookies-and-encryption
+    | for details.
+    |
+    | Set it to true if you want to decrypt cookies.
+    |
+    */
+
+    'decrypt_cookies' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Providers
+    |--------------------------------------------------------------------------
+    |
+    | Specify the various providers used throughout the package.
+    |
+    */
+
+    'providers' => [
+        /*
+        |--------------------------------------------------------------------------
+        | JWT Provider
+        |--------------------------------------------------------------------------
+        |
+        | Specify the provider that is used to create and decode the tokens.
+        |
+        */
+
+        'jwt' => PHPOpenSourceSaver\JWTAuth\Providers\JWT\Lcobucci::class,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Authentication Provider
+        |--------------------------------------------------------------------------
+        |
+        | Specify the provider that is used to authenticate users.
+        |
+        */
+
+        'auth' => PHPOpenSourceSaver\JWTAuth\Providers\Auth\Illuminate::class,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Storage Provider
+        |--------------------------------------------------------------------------
+        |
+        | Specify the provider that is used to store tokens in the blacklist.
+        |
+        */
+
+        'storage' => PHPOpenSourceSaver\JWTAuth\Providers\Storage\Illuminate::class,
+    ],
+];

--- a/xml.postman_collection.json
+++ b/xml.postman_collection.json
@@ -1,0 +1,132 @@
+{
+	"info": {
+		"_postman_id": "109427df-6369-4c01-a772-9011a970169d",
+		"name": "xml",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "502235"
+	},
+	"item": [
+		{
+			"name": "Login",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "email",
+							"value": "test@gmail.com",
+							"type": "text"
+						},
+						{
+							"key": "password",
+							"value": "password",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{host}}/api/app/auth/login",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"api",
+						"app",
+						"auth",
+						"login"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Refresh",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0Ojg4OC9hcGkvYXBwL2F1dGgvbG9naW4iLCJpYXQiOjE2NzQ4NjU5NzIsImV4cCI6MTY3NDg2OTU3MiwibmJmIjoxNjc0ODY1OTcyLCJqdGkiOiJQdVVTeWgwaFpZTGgzQmVpIiwic3ViIjoiMSIsInBydiI6IjU0MDdiMDE3OTc0ZTkzNmUxZjUzOTU1YzBkMTBiMjVjN2MwNDNlM2MifQ.02OZ22-hffJI3gH6DR2mk8KwdSnbXoFRlzihq_PDoVA",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{host}}/api/app/auth/refresh-token",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"api",
+						"app",
+						"auth",
+						"refresh-token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Logout",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0Ojg4OC9hcGkvYXBwL2F1dGgvbG9naW4iLCJpYXQiOjE2NzQ4NjU5NzIsImV4cCI6MTY3NDg2OTU3MiwibmJmIjoxNjc0ODY1OTcyLCJqdGkiOiJQdVVTeWgwaFpZTGgzQmVpIiwic3ViIjoiMSIsInBydiI6IjU0MDdiMDE3OTc0ZTkzNmUxZjUzOTU1YzBkMTBiMjVjN2MwNDNlM2MifQ.02OZ22-hffJI3gH6DR2mk8KwdSnbXoFRlzihq_PDoVA",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{host}}/api/app/auth/logout",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"api",
+						"app",
+						"auth",
+						"logout"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "host",
+			"value": "http://localhost:888",
+			"type": "string"
+		}
+	]
+}


### PR DESCRIPTION
Used [this](https://packagist.org/packages/php-open-source-saver/jwt-auth) package for JWT implementation. Package itself based on older [solution](https://github.com/tymondesigns/jwt-auth). 

1. Add **AuthController** according to the requirements and hint specified in the issue
2. Add postman dump for simpler checking of three newly added API endpoints
3. Update few files. Mostly minor changes

Task itself didn't took long enough to finish (~2.5 h). Main thing which i stumbled upon is the structure of the folders/files which for example broke database factory seeding logic, which didn't allow to populate the database quickly )

One thing worth mentioning is related to the **ServiceProvider.php** file. According to what i saw in the code there already was an **auth:api** middleware and by the logic it seems obvious to fit my solution in it without any radical changes to other parts  of the code) But to be short i stopped on simply moving login route out of the specified scope.

Anyway, it was quite interesting to see something new in terms of implementation )